### PR TITLE
feat: エラー通知、言語切替用スイッチャーを作成

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -13,5 +13,7 @@
   "close": { "message": "Close" },
   "minutes": { "message": "min" },
   "seconds": { "message": "sec" },
-  "custom": { "message": "Custom" }
+  "custom": { "message": "Custom" },
+  "invalidTimeRangeHeading": { "message": "Time Setting Error" },
+  "invalidTimeRangeBody": { "message": "The start time and end time are the same. Please change them." }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -13,5 +13,7 @@
   "close": { "message": "閉じる" },
   "minutes": { "message": "分" },
   "seconds": { "message": "秒" },
-  "custom": { "message": "カスタム" }
+  "custom": { "message": "カスタム" },
+  "invalidTimeRangeHeading": { "message": "時刻設定エラー" },
+  "invalidTimeRangeBody": { "message": "開始時刻と終了時刻が同じです。変更してください。" }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "default_locale": "ja",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "__MSG_extDesc__",
   "author": "Shimizu",
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,8 @@
     "128": "icons/icon128.png"
   },
   "permissions": [
-    "sidePanel"
+    "sidePanel",
+    "storage"
   ],
   "background": {
     "service_worker": "background.js"

--- a/sidepanel.ts
+++ b/sidepanel.ts
@@ -483,7 +483,7 @@ function ensureErrorBanner(): HTMLDivElement {
   iconWrap.style.justifyContent = 'flex-start';
   iconWrap.style.width = '32px';
   iconWrap.style.height = 'auto';
-  iconWrap.style.marginTop = '-18px'; // いい感じの位置。
+  iconWrap.style.marginTop = '-18px'; // Adjusts icon vertical position to visually align with the banner's top edge, compensating for SVG height and padding.
   iconWrap.style.color = '#ec0000';
   iconWrap.innerHTML = `
     <svg class="dads-notification-banner__icon" width="64" height="64" viewBox="0 0 26 26" role="img" aria-label="エラー" style="display:block;vertical-align:top;transform:translateY(-2px);">

--- a/timerLogic.ts
+++ b/timerLogic.ts
@@ -79,8 +79,11 @@ export class ExamTimer {
     if (this.status !== 'idle') return;
 
     if (this.totalDurationSeconds <= 0) {
+      // 不正な時間（開始時刻 = 終了時刻）をUIへ通知
+      window.dispatchEvent(new CustomEvent('exam-timer-error', {
+        detail: { code: 'INVALID_TIME_RANGE' }
+      }));
       console.error("終了時刻は開始時刻と等しいか、それ以前に設定されています。");
-      // UIにエラーを通知する仕組みを後で追加 (v1.0.1 を予定)
       return;
     }
 


### PR DESCRIPTION
# v1.0.1 (2025-08-09)

- 開始時刻と終了時刻に同じ時刻が設定されているとき、エラーを通知するように。
  - デザインはデジタル庁デザインシステムを参考にさせていただきました。ありがとうございます。
- 言語切替用のスイッチャーを追加。これにより、Chrome の言語設定に依存することなく手動で変更可能に。
  - 表示言語を保存するため、権限を更新。( storage 権限を追加。)
 
 
 
<img width="200"  alt="image" src="https://github.com/user-attachments/assets/a665f31d-d562-45ea-88e0-38327cba387d" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/04c1e66e-1101-4eb3-b328-b5c07497a8b4" />
